### PR TITLE
入力画像サイズが416x416であることをconvert.pyで明示的に指定

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -85,7 +85,7 @@ def _main(args):
     cfg_parser.read_file(unique_config_file)
 
     print('Creating Keras model.')
-    input_layer = Input(shape=(None, None, 3))
+    input_layer = Input(shape=(416, 416, 3))
     prev_layer = input_layer
     all_layers = []
 


### PR DESCRIPTION
入力画像サイズが(None, None)になっていたのが原因でconvert_keras_tflite.pyがコケていたので修正しました。